### PR TITLE
#18 combine name and email display

### DIFF
--- a/ckanext/scheming/ckan_dataset.json
+++ b/ckanext/scheming/ckan_dataset.json
@@ -55,7 +55,8 @@
       "field_name": "author",
       "label": "Author",
       "form_placeholder": "Joe Bloggs",
-      "display_property": "dc:creator"
+      "display_property": "dc:creator",
+      "display_field": false
     },
     {
       "field_name": "author_email",
@@ -69,7 +70,8 @@
       "field_name": "maintainer",
       "label": "Maintainer",
       "form_placeholder": "Joe Bloggs",
-      "display_property": "dc:contributor"
+      "display_property": "dc:contributor",
+      "display_field": false
     },
     {
       "field_name": "maintainer_email",


### PR DESCRIPTION
As discussed in (messy and closed) PR #22 this PR combines the display of name/email combo fields by hiding the name field, and letting the email field render the email address (if given) with the specified name field (if given).