### PR TITLE
format existing datetime to date only in form and display snippets

### DIFF
--- a/ckanext/scheming/presets.json
+++ b/ckanext/scheming/presets.json
@@ -81,6 +81,7 @@
       "preset_name": "date",
       "values": {
         "form_snippet": "date.html",
+        "display_snippet": "date.html",
         "validators": "scheming_required isodate"
       }
     }

--- a/ckanext/scheming/templates/scheming/display_snippets/date.html
+++ b/ckanext/scheming/templates/scheming/display_snippets/date.html
@@ -1,0 +1,1 @@
+{{ h.render_datetime(data[field.field_name], date_format='%Y-%m-%d') }}

--- a/ckanext/scheming/templates/scheming/form_snippets/date.html
+++ b/ckanext/scheming/templates/scheming/form_snippets/date.html
@@ -5,7 +5,7 @@
     label=h.scheming_language_text(field.label),
     placeholder=h.scheming_language_text(field.form_placeholder),
     type='date',
-    value=data[field.field_name],
+    value=h.render_datetime(data[field.field_name], date_format='%Y-%m-%d'),
     error=errors[field.field_name],
     classes=['control-medium'],
     attrs=field.form_attrs if 'form_attrs' in field else {},


### PR DESCRIPTION
Addressing #24 this hides the time component of CKAN's datetime fields in ckanext-scheming's date preset.