### PR TITLE
Fix exception in scheming_language_text.

### DIFF
--- a/ckanext/scheming/helpers.py
+++ b/ckanext/scheming/helpers.py
@@ -12,14 +12,21 @@ def scheming_language_text(text, prefer_lang=None, _gettext=None):
     languag in dict or using gettext if not a dict
     """
     if hasattr(text, 'get'):
-        if prefer_lang is None:
-            prefer_lang = lang()
-        v = text.get(prefer_lang)
-        if not v:
-            v = text.get(config.get('ckan.locale_default', 'en'))
-            if not v:
+        if not text:
+            return ''
+
+        prefer_lang = prefer_lang or lang()
+        default_locale = config.get('ckan.locale_default', 'en')
+
+        try:
+            v = text[prefer_lang]
+        except KeyError:
+            try:
+                v = text[default_locale]
+            except KeyError:
                 # just give me something to display
                 l, v = sorted(text.items())[0]
+
         return v
     else:
         if _gettext is None:


### PR DESCRIPTION
If the dict passed to scheming_language_text was empty,
it would crash when it tries getting the first result
from sorted().

Short-circuit an empty "text" value. Also uses exceptions
instead of get() chains (performs better when not using a
default on get(), and in the case where you *usually* expect
there to be a value for that key.)