### PR TITLE
Prefix config options with 'ckanext.'

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,20 @@ Set the schemas you want to use with configuration options:
 ckan.plugins = scheming_datasets
 
 #   module-path:file to schemas being used
-scheming.dataset_schemas = ckanext.spatialx:spatialx_schema.json
-                           ckanext.spatialx:spatialxy_schema.json
+ckanext.scheming.dataset_schemas = ckanext.spatialx:spatialx_schema.json
+                                   ckanext.spatialx:spatialxy_schema.json
 #   will try to load "spatialx_schema.json" and "spatialxy_schema.json"
 #   as dataset schemas
 #
 #   URLs may also be used, e.g:
 #
-# scheming.dataset_schemas = http://example.com/spatialx_schema.json
+# ckanext.scheming.dataset_schemas = http://example.com/spatialx_schema.json
 
 #   Preset files may be included as well. The default preset setting is:
-scheming.presets = ckanext.scheming:presets.json
+ckanext.scheming.presets = ckanext.scheming:presets.json
 
 #   The is_fallback setting may be changed as well. Defaults to false:
-scheming.dataset_fallback = false
+ckanext.scheming.dataset_fallback = false
 ```
 
 
@@ -48,7 +48,7 @@ Example dataset schemas
 * [camel photos schema](ckanext/scheming/camel_photos.json)
 
 These schemas are included in ckanext-scheming and may be enabled
-with e.g: `scheming.dataset_schemas = ckanext.scheming:camel_photos.json`
+with e.g: `ckanext.scheming.dataset_schemas = ckanext.scheming:camel_photos.json`
 
 These schemas use [presets](#preset) defined in
 [presets.json](ckanext/scheming/presets.json).
@@ -204,7 +204,7 @@ This extension includes the following presets:
 * `"resource_format_autocomplete"` - resource format validation with
   format guessing based on url and autocompleting form field
 
-You may add your own presets by adding them to the `scheming.presets`
+You may add your own presets by adding them to the `ckanext.scheming.presets`
 configuration setting.
 
 

--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -83,13 +83,21 @@ class _SchemingMixin(object):
     def _load_presets(self, config):
         if _SchemingMixin._presets is not None:
             return
-        presets = config.get('scheming.presets', DEFAULT_PRESETS).split()
+        presets = config.get('ckanext.scheming.presets', DEFAULT_PRESETS).split()
         _SchemingMixin._presets = {}
         for f in reversed(presets):
             for p in _load_schema(f)['presets']:
                 _SchemingMixin._presets[p['preset_name']] = p['values']
 
     def update_config(self, config):
+
+        # Check for old 'scheming.*' config options
+        new_options = {}
+        for key, value in config.iteritems():
+            if key.startswith('scheming.'):
+                new_options['ckanext.' + key] = value
+        config.update(new_options)
+
         if self.instance:
             # reloading plugins, probably in WebTest
             _SchemingMixin._helpers_loaded = False
@@ -159,8 +167,8 @@ class SchemingDatasetsPlugin(p.SingletonPlugin, DefaultDatasetForm,
     p.implements(p.IActions)
     p.implements(p.IValidators)
 
-    SCHEMA_OPTION = 'scheming.dataset_schemas'
-    FALLBACK_OPTION = 'scheming.dataset_fallback'
+    SCHEMA_OPTION = 'ckanext.scheming.dataset_schemas'
+    FALLBACK_OPTION = 'ckanext.scheming.dataset_fallback'
     SCHEMA_TYPE_FIELD = 'dataset_type'
 
     @classmethod
@@ -230,8 +238,8 @@ class SchemingGroupsPlugin(p.SingletonPlugin, _GroupOrganizationMixin,
     p.implements(p.IActions)
     p.implements(p.IValidators)
 
-    SCHEMA_OPTION = 'scheming.group_schemas'
-    FALLBACK_OPTION = 'scheming.group_fallback'
+    SCHEMA_OPTION = 'ckanext.scheming.group_schemas'
+    FALLBACK_OPTION = 'ckanext.scheming.group_fallback'
     SCHEMA_TYPE_FIELD = 'group_type'
 
     @classmethod
@@ -260,8 +268,8 @@ class SchemingOrganizationsPlugin(p.SingletonPlugin, _GroupOrganizationMixin,
     p.implements(p.IActions)
     p.implements(p.IValidators)
 
-    SCHEMA_OPTION = 'scheming.organization_schemas'
-    FALLBACK_OPTION = 'scheming.organization_fallback'
+    SCHEMA_OPTION = 'ckanext.scheming.organization_schemas'
+    FALLBACK_OPTION = 'ckanext.scheming.organization_fallback'
     SCHEMA_TYPE_FIELD = 'organization_type'
     UNSPECIFIED_GROUP_TYPE = 'organization'
 


### PR DESCRIPTION
To avoid clashes with other extensions or external libraries and to keep
things tidy.

The old `scheming.*` options are still fully supported.