### PR TITLE
 Don't render a list if there is only one option

### DIFF
--- a/ckanext/scheming/templates/scheming/display_snippets/multiple_choice.html
+++ b/ckanext/scheming/templates/scheming/display_snippets/multiple_choice.html
@@ -1,8 +1,18 @@
 {%- set values = data[field.field_name] -%}
-<ul>
+{%- set labels = [] -%}
+
 {%- for choice in field.choices -%}
     {%- if choice.value in values -%}
-        <li>{{ h.scheming_language_text(choice.label) }}</li>
+      {%- do labels.append(h.scheming_language_text(choice.label)) -%}
     {%- endif -%}
 {%- endfor -%}
-</ul>
+
+{%- if labels|length == 1 -%}
+  {{ labels[0] }}
+{%- else -%}
+  <ul>
+    {%- for label in labels -%}
+       <li>{{ label }}</li>
+    {%- endfor -%}
+  </ul>
+{%- endif -%}

--- a/ckanext/scheming/tests/test_dataset_display.py
+++ b/ckanext/scheming/tests/test_dataset_display.py
@@ -59,3 +59,33 @@ class TestDatasetDisplay(FunctionalTestBase):
         app = self._get_test_app()
         response = app.get(url='/dataset/plain-jane')
         assert_true('<h1>styled notes' in response.body)
+
+    def test_choice_field_shows_list_if_multiple_options(self):
+        user = Sysadmin()
+        d = Dataset(
+            user=user,
+            type='camel-photos',
+            name='with-multiple-choice-n',
+            personality=['friendly', 'spits'],
+            )
+        app = self._get_test_app()
+        response = app.get(url='/dataset/with-multiple-choice-n')
+
+        assert_true('<ul><li>Often friendly</li><li>Tends to spit</li></ul>'
+                    in response.body)
+
+    def test_choice_field_does_not_show_list_if_one_options(self):
+        user = Sysadmin()
+        d = Dataset(
+            user=user,
+            type='camel-photos',
+            name='with-multiple-choice-one',
+            personality=['friendly'],
+            )
+        app = self._get_test_app()
+        response = app.get(url='/dataset/with-multiple-choice-one')
+
+        assert_true('Often friendly'
+                    in response.body)
+        assert_true('<ul><li>Often friendly</li></ul>'
+                    not in response.body)


### PR DESCRIPTION
If a multiple choice field has only one option, just render the text instead of a list with one item.

This:

![rqmuivz](https://cloud.githubusercontent.com/assets/200230/8984334/cb1af57a-36c8-11e5-9001-f5e8d7486adf.png)

Instead of this:

![pn1t4g6](https://cloud.githubusercontent.com/assets/200230/8984339/d11b2332-36c8-11e5-922e-3cf6228ee7f6.png)
