### PR TITLE
Fix `scheming` command to allow dataset_fields key.

### DIFF
--- a/ckanext/scheming/commands.py
+++ b/ckanext/scheming/commands.py
@@ -40,14 +40,28 @@ class SchemingCommand(CkanCommand):
             print self.__doc__
 
     def _show(self):
-        for n, s in (
-                ("Dataset", scheming_dataset_schemas()),
-                ("Group", scheming_group_schemas()),
-                ("Organization", scheming_organization_schemas()),
-                ):
+        dataset_schema = scheming_dataset_schemas()
+
+        resource_schema = None
+        if dataset_schema and dataset_schema['dataset'].get('resource_fields'):
+            resource_schema = \
+                {'resource':
+                    {'fields':
+                     dataset_schema['dataset'].get('resource_fields')}}
+
+        schemas = [
+            ("Dataset", dataset_schema),
+            ("Resource", resource_schema),
+            ("Group", scheming_group_schemas()),
+            ("Organization", scheming_organization_schemas()),
+        ]
+        # and the resource schema...
+        print scheming_group_schemas()
+
+        for n, s in schemas:
             print n, "schemas:"
             if s is None:
-                print "    plugin not loaded\n"
+                print "    plugin not loaded or schema not specified\n"
                 continue
             if not s:
                 print "    no schemas"

--- a/ckanext/scheming/commands.py
+++ b/ckanext/scheming/commands.py
@@ -1,5 +1,4 @@
 from ckan.lib.cli import CkanCommand
-import ckan.plugins as p
 import paste.script
 
 from ckanext.scheming.helpers import (
@@ -8,10 +7,7 @@ from ckanext.scheming.helpers import (
     scheming_organization_schemas,
     )
 
-import sys
 import json
-from datetime import datetime
-from contextlib import contextmanager
 
 
 class SchemingCommand(CkanCommand):
@@ -28,7 +24,8 @@ class SchemingCommand(CkanCommand):
 
     parser = paste.script.command.Command.standard_parser(verbose=True)
     parser.add_option('-c', '--config', dest='config',
-        default='development.ini', help='Config file to use.')
+                      default='development.ini',
+                      help='Config file to use.')
 
     def command(self):
         cmd = self.args[0]
@@ -40,23 +37,11 @@ class SchemingCommand(CkanCommand):
             print self.__doc__
 
     def _show(self):
-        dataset_schema = scheming_dataset_schemas()
-
-        resource_schema = None
-        if dataset_schema and dataset_schema['dataset'].get('resource_fields'):
-            resource_schema = \
-                {'resource':
-                    {'fields':
-                     dataset_schema['dataset'].get('resource_fields')}}
-
         schemas = [
-            ("Dataset", dataset_schema),
-            ("Resource", resource_schema),
+            ("Dataset", scheming_dataset_schemas()),
             ("Group", scheming_group_schemas()),
             ("Organization", scheming_organization_schemas()),
         ]
-        # and the resource schema...
-        print scheming_group_schemas()
 
         for n, s in schemas:
             print n, "schemas:"
@@ -67,9 +52,12 @@ class SchemingCommand(CkanCommand):
                 print "    no schemas"
             for typ in sorted(s):
                 print " * " + json.dumps(typ)
-                field_name = 'dataset_fields' if s[typ].get('dataset_fields') \
-                    else 'fields'
-                for field in s[typ][field_name]:
-                    print "   - " + json.dumps(field['field_name'])
+                field_names = ('dataset_fields', 'fields', 'resource_fields')
 
+                for field_name in field_names:
+                    if s[typ].get(field_name):
+                        if field_name == 'resource_fields':
+                            print " * " + json.dumps("resource")
+                        for field in s[typ][field_name]:
+                            print "   - " + json.dumps(field['field_name'])
             print

--- a/ckanext/scheming/commands.py
+++ b/ckanext/scheming/commands.py
@@ -30,7 +30,6 @@ class SchemingCommand(CkanCommand):
     parser.add_option('-c', '--config', dest='config',
         default='development.ini', help='Config file to use.')
 
-
     def command(self):
         cmd = self.args[0]
         self._load_config()
@@ -54,7 +53,9 @@ class SchemingCommand(CkanCommand):
                 print "    no schemas"
             for typ in sorted(s):
                 print " * " + json.dumps(typ)
-                for field in s[typ]['fields']:
+                field_name = 'dataset_fields' if s[typ].get('dataset_fields') \
+                    else 'fields'
+                for field in s[typ][field_name]:
                     print "   - " + json.dumps(field['field_name'])
-            print
 
+            print


### PR DESCRIPTION
Group and Org schemas use `fields` as the key to the array within the
schema json file. Dataset schemas use `dataset_fields`. This commit
stops the `scheming` command from breaking when printing dataset fields.