### PR TITLE
Move test.ini and add README notes for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,3 +332,16 @@ Help text may be provided in multiple languages like [label fields](#label).
 ### `help_inline`
 
 Display help text inline if set to `true`. Default is `false`.
+
+
+Running the Tests
+=================
+
+To run the tests, do:
+
+```nosetests --ckan --nologcapture --with-pylons=test.ini```
+
+To run the tests and produce a coverage report, first make sure you have
+coverage installed in your virtualenv (``pip install coverage``) then run:
+
+```nosetests --ckan --nologcapture --with-pylons=test.ini --with-coverage --cover-package=ckanext.scheming --cover-inclusive --cover-erase --cover-tests```

--- a/README.md
+++ b/README.md
@@ -341,6 +341,10 @@ To run the tests, do:
 
 ```nosetests --ckan --nologcapture --with-pylons=test.ini```
 
+and
+
+```nosetests --ckan --nologcapture --with-pylons=test_subclass.ini ckanext.scheming.tests.test_dataset_display ckanext.scheming.tests.test_form ckanext.scheming.tests.test_dataset_logic```
+
 To run the tests and produce a coverage report, first make sure you have
 coverage installed in your virtualenv (``pip install coverage``) then run:
 

--- a/bin/travis-install
+++ b/bin/travis-install
@@ -10,35 +10,29 @@ sudo apt-get install solr-jetty postgresql-$PGVERSION libgeos-c1
 sudo -u postgres psql -c "CREATE USER ckan_default WITH PASSWORD 'pass';"
 sudo -u postgres psql -c 'CREATE DATABASE ckan_test WITH OWNER ckan_default;'
 
-mkdir dl
-cd dl
 git clone https://github.com/ckan/ckan
-cd -
-cd dl/ckan
+cd ckan
 python setup.py develop
-# not interested in building CSS, just use production one
-cp ./ckan/public/base/css/main.css ./ckan/public/base/css/main.debug.css
+pip install -r requirements.txt --allow-all-external
+pip install -r dev-requirements.txt --allow-all-external
 cd -
 
-mkdir links
-ln -s ../dl/ckan links/ckan
-pip install -r links/ckan/requirements.txt --allow-all-external
-pip install -r links/ckan/dev-requirements.txt --allow-all-external
-pip install -r requirements.txt --allow-all-external
+echo "Initialising the database..."
+cd ckan
+paster db init -c test-core.ini
+cd -
 
-python setup.py install
+echo "Installing ckanext-scheming and its requirements..."
+python setup.py develop
+pip install -r requirements.txt
 
 # Configure Solr
 echo "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
 # FIXME the solr schema cannot be hardcoded as it is dependent on the ckan version
-sudo cp links/ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
+sudo cp ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
 sudo service jetty restart
 
-SCHEMING_DIR="`pwd`"
-CKAN_DIR="`python -c'import ckan; print ckan.__file__.rsplit("/",2)[0]'`"
-cd "$CKAN_DIR"
-
-echo setting up databases
-paster db init -c test-core.ini
-
-cd -
+echo "Moving test.ini into a subdir..."
+mkdir subdir
+mv test.ini subdir
+mv test_subclass.ini subdir

--- a/bin/travis-script
+++ b/bin/travis-script
@@ -7,5 +7,4 @@ nosetests --with-pylons=subdir/test_subclass.ini --nologcapture \
 	ckanext.scheming.tests.test_form \
 	ckanext.scheming.tests.test_dataset_logic
 nosetests --with-pylons=subdir/test.ini --nologcapture \
-	--with-coverage --cover-package=ckanext.scheming \
-	ckanext.scheming.tests
+	--with-coverage --cover-package=ckanext.scheming

--- a/bin/travis-script
+++ b/bin/travis-script
@@ -1,12 +1,11 @@
 #!/bin/sh
 
 set -e
-cd ckanext/scheming/tests
 
-nosetests --with-pylons=test_subclass.ini --nologcapture \
+nosetests --with-pylons=subdir/test_subclass.ini --nologcapture \
 	ckanext.scheming.tests.test_dataset_display \
 	ckanext.scheming.tests.test_form \
 	ckanext.scheming.tests.test_dataset_logic
-nosetests --with-pylons=test.ini --nologcapture \
+nosetests --with-pylons=subdir/test.ini --nologcapture \
 	--with-coverage --cover-package=ckanext.scheming \
 	ckanext.scheming.tests

--- a/test.ini
+++ b/test.ini
@@ -9,7 +9,7 @@ host = 0.0.0.0
 port = 5000
 
 [app:main]
-use = config:../../../links/ckan/test-core.ini
+use = config:../ckan/test-core.ini
 
 ckan.plugins = scheming_datasets scheming_groups scheming_organizations
 scheming.dataset_schemas = ckanext.scheming:ckan_dataset.json

--- a/test_subclass.ini
+++ b/test_subclass.ini
@@ -9,7 +9,7 @@ host = 0.0.0.0
 port = 5000
 
 [app:main]
-use = config:../../../links/ckan/test-core.ini
+use = config:../ckan/test-core.ini
 
 ckan.plugins = scheming_test_subclass
 scheming.dataset_schemas = ckanext.scheming:camel_photos.json


### PR DESCRIPTION
This moves test.ini to the standard location, assuming the extension is installed beside ckan. Fixes #63.