### PR TITLE
fixed #92 by repeating first argument for h.link_to

### DIFF
--- a/ckanext/scheming/templates/scheming/display_snippets/link.html
+++ b/ckanext/scheming/templates/scheming/display_snippets/link.html
@@ -1,1 +1,1 @@
-{{ h.link_to(data[field.field_name], rel=field.display_property, target='_blank') }}
+{{ h.link_to(data[field.field_name], data[field.field_name], rel=field.display_property, target='_blank') }}


### PR DESCRIPTION
This patch adds a `href` value to the display snippet `link.html`, so the snippet links to the field value rather than reloading the current page.